### PR TITLE
Add method to handle kOfxMeshEffectActionIsIdentity

### DIFF
--- a/CppPluginSupport/src/MfxAttribute.cpp
+++ b/CppPluginSupport/src/MfxAttribute.cpp
@@ -1,6 +1,8 @@
 #include "MfxAttribute.h"
 #include "macros.h"
 
+#include <cstring>
+
 MfxAttribute::MfxAttribute(const MfxHost& host, OfxPropertySetHandle properties)
 	: MfxBase(host)
 	, m_properties(properties)

--- a/CppPluginSupport/src/MfxEffect.cpp
+++ b/CppPluginSupport/src/MfxEffect.cpp
@@ -48,6 +48,10 @@ OfxStatus MfxEffect::MainEntry(const char *action,
             SetupCook((OfxMeshEffectHandle)handle);
             return Cook((OfxMeshEffectHandle)handle);
         }
+        if (0 == strcmp(action, kOfxMeshEffectActionIsIdentity)) {
+            SetupIsIdentity((OfxMeshEffectHandle)handle);
+            return IsIdentity((OfxMeshEffectHandle)handle);
+        }
         return kOfxStatReplyDefault;
     }
     catch (MfxSuiteException &e)
@@ -163,6 +167,12 @@ void MfxEffect::SetupDescribe(OfxMeshEffectHandle descriptor)
 }
 
 void MfxEffect::SetupCook(OfxMeshEffectHandle instance)
+{
+    m_instance = instance;
+    MFX_ENSURE(meshEffectSuite->getParamSet(instance, &m_parameters));
+}
+
+void MfxEffect::SetupIsIdentity(OfxMeshEffectHandle instance)
 {
     m_instance = instance;
     MFX_ENSURE(meshEffectSuite->getParamSet(instance, &m_parameters));

--- a/CppPluginSupport/src/MfxEffect.cpp
+++ b/CppPluginSupport/src/MfxEffect.cpp
@@ -3,6 +3,7 @@
 #include "macros.h"
 
 #include <iostream>
+#include <cstring>
 
 void MfxEffect::SetHost(OfxHost* host)
 {

--- a/CppPluginSupport/src/MfxEffect.h
+++ b/CppPluginSupport/src/MfxEffect.h
@@ -47,6 +47,9 @@ protected:
 	virtual OfxStatus Cook(OfxMeshEffectHandle instance)
 	{ return kOfxStatOK; }
 
+    virtual OfxStatus IsIdentity(OfxMeshEffectHandle instance)
+    { return kOfxStatReplyDefault; }
+
 protected:
 	// Utility methods to be used during the Describe() action only:
 
@@ -87,6 +90,13 @@ private:
 	 * in the Cook() action.
 	 */
 	void SetupCook(OfxMeshEffectHandle instance);
+
+    /**
+     * Cache the current instance and its parameter set to avoid providing
+     * it to each call to GetInput and GetParameter while evaluating whether
+     * the effect should be cooked in the IsIdentity() action.
+     */
+    void SetupIsIdentity(OfxMeshEffectHandle instance);
 
 protected:
 	const MfxHost & host() const { return m_host; }

--- a/CppPluginSupport/src/MfxParam.cpp
+++ b/CppPluginSupport/src/MfxParam.cpp
@@ -9,6 +9,7 @@ MfxParam<T>::MfxParam(const MfxHost& host, OfxParamHandle param)
 
 //-----------------------------------------------------------------------------
 
+template<>
 int MfxParam<int>::GetValue()
 {
 	int value = 0;
@@ -16,6 +17,7 @@ int MfxParam<int>::GetValue()
 	return value;
 }
 
+template<>
 int2 MfxParam<int2>::GetValue()
 {
 	int2 value = { 0, 0 };
@@ -23,6 +25,7 @@ int2 MfxParam<int2>::GetValue()
 	return value;
 }
 
+template<>
 int3 MfxParam<int3>::GetValue()
 {
 	int3 value = { 0, 0, 0 };
@@ -30,6 +33,7 @@ int3 MfxParam<int3>::GetValue()
 	return value;
 }
 
+template<>
 double MfxParam<double>::GetValue()
 {
 	double value = 0;
@@ -37,6 +41,7 @@ double MfxParam<double>::GetValue()
 	return value;
 }
 
+template<>
 double2 MfxParam<double2>::GetValue()
 {
 	double2 value = { 0, 0 };
@@ -44,6 +49,7 @@ double2 MfxParam<double2>::GetValue()
 	return value;
 }
 
+template<>
 double3 MfxParam<double3>::GetValue()
 {
 	double3 value = { 0, 0, 0 };
@@ -51,9 +57,10 @@ double3 MfxParam<double3>::GetValue()
 	return value;
 }
 
+template<>
 bool MfxParam<bool>::GetValue()
 {
-	bool value = 0;
+	bool value = false;
 	MFX_ENSURE(parameterSuite->paramGetValue(m_param, &value));
 	return value;
 }


### PR DESCRIPTION
Hi, I recently implemented `IsIdentity` action for MfxVTK ( https://github.com/tkarabela/MfxVTK/commit/bfd383afcce00a2a7d5178bd25039a57b6324478 ), it's available in MfxVTK 0.3.0. This is the code needed to support it in `CppPluginSupport`.