### PR TITLE
CppPluginSupport - add attribute forwarding, NoLooseEdge and ConstantFaceCount

### DIFF
--- a/CppPluginSupport/src/MfxAttribute.h
+++ b/CppPluginSupport/src/MfxAttribute.h
@@ -16,6 +16,12 @@ private:
 	 * Convert a type string from MeshEffect API to its local enum counterpart
 	 */
 	static MfxAttributeType mfxAttrAsEnum(const char* mfxType);
+
+    /**
+     * Convert local typestring enum to a type string from MeshEffect API
+     */
+    static const char* mfxAttrAsString(MfxAttributeType mfxType);
+
 	/**
 	 * Copy attribute and try to cast. If number of component is different,
 	 * copy the common components only.
@@ -24,13 +30,25 @@ private:
 
 public:
 	/**
-	 * Populate the provided props structure woth this attribute's properties
+	 * Populate the provided props structure with this attribute's properties
 	 */
 	void FetchProperties(MfxAttributeProps & props);
 
+    /**
+     * Set attribute properties according to provided props structure
+     */
+    void SetProperties(const MfxAttributeProps & props);
+
+    /**
+     * Copy attribute data, casting if necessary
+     */
 	void CopyFrom(MfxAttribute& other, int start, int count);
+
+    /**
+     * Forward attribute data, pointing to existing buffers instead of copying
+     */
+    void ForwardFrom(MfxAttribute& other);
 
 private:
 	OfxPropertySetHandle m_properties;
 };
-

--- a/CppPluginSupport/src/MfxAttribute.h
+++ b/CppPluginSupport/src/MfxAttribute.h
@@ -45,7 +45,8 @@ public:
 	void CopyFrom(MfxAttribute& other, int start, int count);
 
     /**
-     * Forward attribute data, pointing to existing buffers instead of copying
+     * Forward attribute data, pointing to existing buffers instead of copying.
+     * Note that the buffer in source attribute must already be allocated.
      */
     void ForwardFrom(MfxAttribute& other);
 

--- a/CppPluginSupport/src/MfxAttributeProps.h
+++ b/CppPluginSupport/src/MfxAttributeProps.h
@@ -14,8 +14,11 @@ enum class MfxAttributeType {
  */
 struct MfxAttributeProps
 {
+    MfxAttributeProps() : type(MfxAttributeType::Unknown), stride(0), componentCount(0), data(NULL), isOwner(false) {}
+
     MfxAttributeType type;
     int stride;
     int componentCount;
     char* data;
+    bool isOwner;
 };

--- a/CppPluginSupport/src/MfxMesh.cpp
+++ b/CppPluginSupport/src/MfxMesh.cpp
@@ -13,7 +13,9 @@ void MfxMesh::FetchProperties(MfxMeshProps& props)
 {
 	MFX_ENSURE(propertySuite->propGetInt(m_properties, kOfxMeshPropPointCount, 0, &props.pointCount));
 	MFX_ENSURE(propertySuite->propGetInt(m_properties, kOfxMeshPropVertexCount, 0, &props.vertexCount));
-	MFX_ENSURE(propertySuite->propGetInt(m_properties, kOfxMeshPropFaceCount, 0, &props.faceCount));
+    MFX_ENSURE(propertySuite->propGetInt(m_properties, kOfxMeshPropFaceCount, 0, &props.faceCount));
+    MFX_ENSURE(propertySuite->propGetInt(m_properties, kOfxMeshPropNoLooseEdge, 0, &props.noLooseEdge));
+    MFX_ENSURE(propertySuite->propGetInt(m_properties, kOfxMeshPropConstantFaceCount, 0, &props.constantFaceCount));
 }
 
 MfxAttribute MfxMesh::GetAttribute(const char* attachment, const char* name)
@@ -78,10 +80,12 @@ MfxAttribute MfxMesh::AddMeshAttribute(const char* name, int componentCount, con
 	return AddAttribute(kOfxMeshAttribMesh, name, componentCount, type);
 }
 
-void MfxMesh::Allocate(int pointCount, int vertCount, int faceCount)
+void MfxMesh::Allocate(int pointCount, int vertCount, int faceCount, int noLooseEdge, int constantFaceCount)
 {
 	MFX_ENSURE(propertySuite->propSetInt(m_properties, kOfxMeshPropPointCount, 0, pointCount));
 	MFX_ENSURE(propertySuite->propSetInt(m_properties, kOfxMeshPropVertexCount, 0, vertCount));
-	MFX_ENSURE(propertySuite->propSetInt(m_properties, kOfxMeshPropFaceCount, 0, faceCount));
+    MFX_ENSURE(propertySuite->propSetInt(m_properties, kOfxMeshPropFaceCount, 0, faceCount));
+    MFX_ENSURE(propertySuite->propSetInt(m_properties, kOfxMeshPropNoLooseEdge, 0, noLooseEdge));
+    MFX_ENSURE(propertySuite->propSetInt(m_properties, kOfxMeshPropConstantFaceCount, 0, constantFaceCount));
 	MFX_ENSURE(meshEffectSuite->meshAlloc(m_mesh));
 }

--- a/CppPluginSupport/src/MfxMesh.cpp
+++ b/CppPluginSupport/src/MfxMesh.cpp
@@ -11,11 +11,15 @@ MfxMesh::MfxMesh(const MfxHost& host, OfxMeshHandle mesh, OfxPropertySetHandle p
 
 void MfxMesh::FetchProperties(MfxMeshProps& props)
 {
-	MFX_ENSURE(propertySuite->propGetInt(m_properties, kOfxMeshPropPointCount, 0, &props.pointCount));
+	int noLooseEdge;
+
+    MFX_ENSURE(propertySuite->propGetInt(m_properties, kOfxMeshPropPointCount, 0, &props.pointCount));
 	MFX_ENSURE(propertySuite->propGetInt(m_properties, kOfxMeshPropVertexCount, 0, &props.vertexCount));
     MFX_ENSURE(propertySuite->propGetInt(m_properties, kOfxMeshPropFaceCount, 0, &props.faceCount));
-    MFX_ENSURE(propertySuite->propGetInt(m_properties, kOfxMeshPropNoLooseEdge, 0, &props.noLooseEdge));
+    MFX_ENSURE(propertySuite->propGetInt(m_properties, kOfxMeshPropNoLooseEdge, 0, &noLooseEdge));
     MFX_ENSURE(propertySuite->propGetInt(m_properties, kOfxMeshPropConstantFaceCount, 0, &props.constantFaceCount));
+
+    props.noLooseEdge = (bool)noLooseEdge;
 }
 
 MfxAttribute MfxMesh::GetAttribute(const char* attachment, const char* name)
@@ -80,12 +84,12 @@ MfxAttribute MfxMesh::AddMeshAttribute(const char* name, int componentCount, con
 	return AddAttribute(kOfxMeshAttribMesh, name, componentCount, type);
 }
 
-void MfxMesh::Allocate(int pointCount, int vertCount, int faceCount, int noLooseEdge, int constantFaceCount)
+void MfxMesh::Allocate(int pointCount, int vertCount, int faceCount, bool noLooseEdge, int constantFaceCount)
 {
 	MFX_ENSURE(propertySuite->propSetInt(m_properties, kOfxMeshPropPointCount, 0, pointCount));
 	MFX_ENSURE(propertySuite->propSetInt(m_properties, kOfxMeshPropVertexCount, 0, vertCount));
     MFX_ENSURE(propertySuite->propSetInt(m_properties, kOfxMeshPropFaceCount, 0, faceCount));
-    MFX_ENSURE(propertySuite->propSetInt(m_properties, kOfxMeshPropNoLooseEdge, 0, noLooseEdge));
+    MFX_ENSURE(propertySuite->propSetInt(m_properties, kOfxMeshPropNoLooseEdge, 0, (int)noLooseEdge));
     MFX_ENSURE(propertySuite->propSetInt(m_properties, kOfxMeshPropConstantFaceCount, 0, constantFaceCount));
 	MFX_ENSURE(meshEffectSuite->meshAlloc(m_mesh));
 }

--- a/CppPluginSupport/src/MfxMesh.h
+++ b/CppPluginSupport/src/MfxMesh.h
@@ -15,7 +15,7 @@ private:
 
 public:
 	/**
-	 * Populate the provided props structure woth this attribute's properties
+	 * Populate the provided props structure with this attribute's properties
 	 */
 	void FetchProperties(MfxMeshProps& props);
 
@@ -40,7 +40,7 @@ public:
 	MfxAttribute AddFaceAttribute(const char* name, int componentCount, const char* type);
 	MfxAttribute AddMeshAttribute(const char* name, int componentCount, const char* type);
 
-    void Allocate(int pointCount, int vertCount, int faceCount, int noLooseEdge=1, int constantFaceCount=-1);
+    void Allocate(int pointCount, int vertCount, int faceCount, bool noLooseEdge=true, int constantFaceCount=-1);
 
 private:
 	OfxMeshHandle m_mesh;

--- a/CppPluginSupport/src/MfxMesh.h
+++ b/CppPluginSupport/src/MfxMesh.h
@@ -40,7 +40,7 @@ public:
 	MfxAttribute AddFaceAttribute(const char* name, int componentCount, const char* type);
 	MfxAttribute AddMeshAttribute(const char* name, int componentCount, const char* type);
 
-	void Allocate(int pointCount, int vertCount, int faceCount);
+    void Allocate(int pointCount, int vertCount, int faceCount, int noLooseEdge=1, int constantFaceCount=-1);
 
 private:
 	OfxMeshHandle m_mesh;

--- a/CppPluginSupport/src/MfxMeshProps.h
+++ b/CppPluginSupport/src/MfxMeshProps.h
@@ -5,4 +5,6 @@ struct MfxMeshProps
     int pointCount;
     int vertexCount;
     int faceCount;
+    int noLooseEdge;
+    int constantFaceCount;
 };

--- a/CppPluginSupport/src/MfxMeshProps.h
+++ b/CppPluginSupport/src/MfxMeshProps.h
@@ -5,6 +5,6 @@ struct MfxMeshProps
     int pointCount;
     int vertexCount;
     int faceCount;
-    int noLooseEdge;
+    bool noLooseEdge;
     int constantFaceCount;
 };


### PR DESCRIPTION
Hi! While implementing attribute forwarding, NoLooseEdge and ConstantFaceCount for MfxVTK (branch `feature-mesh-optimization-attributes`), I've updated CppPluginSupport to make it possible to use these features: I've added new properties to `MfxMeshProps` and `MfxAttributeProps` and enabled `MfxAttributeProps` to be used for modifying and not just reading attribute properties.

- example - attribute forwarding (`custom buffer -> MfxAttribute`, this really helps)
  - https://github.com/tkarabela/MfxVTK/blob/feature-mesh-optimization-attributes/src/mfx_vtk_plugin/VtkEffectUtils.cpp#L263
- example - attribute forwarding (`MfxAttribute -> MfxAttribute`)
  - https://github.com/tkarabela/MfxVTK/blob/feature-mesh-optimization-attributes/src/mfx_vtk_plugin/mfx_vtk_plugin_extra.cpp#L296