### PR TITLE
Fix CMakeLists duplicate target definition

### DIFF
--- a/CppPluginSupport/CMakeLists.txt
+++ b/CppPluginSupport/CMakeLists.txt
@@ -21,9 +21,11 @@ file(GLOB SRC src/*.cpp src/*.h)
 # Dunno why we need to redefine this even though it has been defined
 # in parent directory but don't have time now to investigate. Redefining
 # here works even though it is not clean.
-add_library(openmesheffect INTERFACE)
-target_include_directories(openmesheffect INTERFACE ../include/)
-add_library(OpenMeshEffect::Core ALIAS openmesheffect)
+if (NOT TARGET OpenMeshEffect::Core)
+    add_library(openmesheffect INTERFACE)
+    target_include_directories(openmesheffect INTERFACE ../include/)
+    add_library(OpenMeshEffect::Core ALIAS openmesheffect)
+endif()
 
 add_library(CppPluginSupport "${SRC}")
 target_link_libraries(CppPluginSupport PUBLIC OpenMeshEffect::Core)


### PR DESCRIPTION
I've tried to `add_subdirectory(OpenMeshEffect)` in MfxVTK and had to make this change to get CMake to build on Linux. It just skips definition if target already exists, so hopefully it shouldn't break anything.

Not sure why the target definition is necessary in the first place, unless one is using `CppPluginSupport/CMakeLists.txt` directly and not through `./CMakeLists.txt`. I use CLion on Linux, which identifies the project with the top-level CMakeList and builds targets from that. Maybe it's a MS Visual Studio thing? I don't know. Anyway, it should be working now.